### PR TITLE
Add the aarch64-helenos target

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -988,6 +988,11 @@ aarch64*-*-freebsd*)
 	tm_file="${tm_file} aarch64/aarch64-elf.h aarch64/aarch64-freebsd.h"
 	tmake_file="${tmake_file} aarch64/t-aarch64 aarch64/t-aarch64-freebsd"
 	;;
+aarch64*-*-helenos*)
+	tm_file="${tm_file} dbxelf.h elfos.h aarch64/aarch64-elf.h"
+	tm_file="${tm_file} helenos-stdint.h aarch64/aarch64-helenos.h helenos.h"
+	tmake_file="${tmake_file} aarch64/t-aarch64 aarch64/t-aarch64-helenos"
+	;;
 aarch64*-*-linux*)
 	tm_file="${tm_file} dbxelf.h elfos.h gnu-user.h linux.h glibc-stdint.h"
 	tm_file="${tm_file} aarch64/aarch64-elf.h aarch64/aarch64-linux.h"

--- a/gcc/config/aarch64/aarch64-helenos.h
+++ b/gcc/config/aarch64/aarch64-helenos.h
@@ -1,0 +1,65 @@
+/* Definitions for HelenOS.
+   Copyright (C) 2018 Free Software Foundation, Inc.
+
+   This file is part of GCC.
+
+   GCC is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3, or (at your option)
+   any later version.
+
+   GCC is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GCC; see the file COPYING3.  If not see
+   <http://www.gnu.org/licenses/>.  */
+
+#ifndef GCC_AARCH64_HELENOS_H
+#define GCC_AARCH64_HELENOS_H
+
+#define HELENOS_TARGET_LINK_SPEC  "%{h*}	\
+   %{static:-Bstatic}				\
+   %{shared:-shared}				\
+   %{symbolic:-Bsymbolic}			\
+   %{!static:%{!static-pie:			\
+     %{rdynamic:-export-dynamic}		\
+     %{!shared:-no-dynamic-linker}}} 		\
+   %{static-pie:-Bstatic -pie --no-dynamic-linker -z text} \
+   -X						\
+   %{mbig-endian:-EB} %{mlittle-endian:-EL}"
+
+#if TARGET_FIX_ERR_A53_835769_DEFAULT
+#define CA53_ERR_835769_SPEC \
+  " %{!mno-fix-cortex-a53-835769:--fix-cortex-a53-835769}"
+#else
+#define CA53_ERR_835769_SPEC \
+  " %{mfix-cortex-a53-835769:--fix-cortex-a53-835769}"
+#endif
+
+#if TARGET_FIX_ERR_A53_843419_DEFAULT
+#define CA53_ERR_843419_SPEC \
+  " %{!mno-fix-cortex-a53-843419:--fix-cortex-a53-843419}"
+#else
+#define CA53_ERR_843419_SPEC \
+  " %{mfix-cortex-a53-843419:--fix-cortex-a53-843419}"
+#endif
+
+#define LINK_SPEC HELENOS_TARGET_LINK_SPEC \
+                  CA53_ERR_835769_SPEC \
+                  CA53_ERR_843419_SPEC
+
+#define TARGET_ASM_FILE_END file_end_indicate_exec_stack
+
+/* Uninitialized common symbols in non-PIE executables, even with
+   strong definitions in dependent shared libraries, will resolve
+   to COPY relocated symbol in the executable.  See PR65780.  */
+#undef TARGET_BINDS_LOCAL_P
+#define TARGET_BINDS_LOCAL_P default_binds_local_p_2
+
+/* Define this to be nonzero if static stack checking is supported.  */
+#define STACK_CHECK_STATIC_BUILTIN 1
+
+#endif  /* GCC_AARCH64_HELENOS_H */

--- a/gcc/config/aarch64/t-aarch64-helenos
+++ b/gcc/config/aarch64/t-aarch64-helenos
@@ -1,0 +1,21 @@
+# Machine description for AArch64 architecture.
+#  Copyright (C) 2018 Free Software Foundation, Inc.
+#
+#  This file is part of GCC.
+#
+#  GCC is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3, or (at your option)
+#  any later version.
+#
+#  GCC is distributed in the hope that it will be useful, but
+#  WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with GCC; see the file COPYING3.  If not see
+#  <http://www.gnu.org/licenses/>.
+
+LIB1ASMSRC   = aarch64/lib1funcs.asm
+LIB1ASMFUNCS = _aarch64_sync_cache_range


### PR DESCRIPTION
Add a HelenOS target for the AArch64 port. The configuration is based on the Linux and FreeBSD targets.